### PR TITLE
Remove reference to absent file Controlb.cpp from Capow project.

### DIFF
--- a/source/Capow.vcxproj
+++ b/source/Capow.vcxproj
@@ -160,7 +160,6 @@
     <ClCompile Include="Cell.cpp" />
     <ClCompile Include="Color.cpp" />
     <ClCompile Include="configure.cpp" />
-    <ClCompile Include="Controlb.cpp" />
     <ClCompile Include="Cycle.cpp" />
     <ClCompile Include="Digital.cpp" />
     <ClCompile Include="Dllmem.cpp" />


### PR DESCRIPTION
Reference to a nonexistent file was causing an error in VS Community 2015. The file CONTROLB.CPP was present and empty in the latest release as well as Capow 2007.